### PR TITLE
fix(ui): enable system color scheme for dark mode controls

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -40,7 +40,7 @@ function App() {
   return (
     <Suspense fallback={<LoadingFallback />}>
       <ThemeProvider theme={theme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
         <HashRouter>
           <Routes>
             <Route path="/add-drive" element={<AddDrive />} />


### PR DESCRIPTION
Use <CssBaseline enableColorScheme /> so browser/system UI controls (e.g. scrollbars) follow the current MUI theme mode (light/dark).

Resolves #18 